### PR TITLE
remove unused hyakumori theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "plugins/redmine_gtt_smash"]
 	path = plugins/redmine_gtt_smash
 	url = https://github.com/gtt-project/redmine_gtt_smash.git
-[submodule "public/themes/hyakumori"]
-	path = public/themes/hyakumori
-	url = https://github.com/hyakumori/redmine_theme_hyakumori.git
 [submodule "public/themes/hyakumori_blueclair"]
 	path = public/themes/hyakumori_blueclair
 	url = https://github.com/hyakumori/redmine_theme_farend_bleuclair.git


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- removes theme no longer used and references archieved repository

@gtt-project/maintainer
